### PR TITLE
Variable drawer width

### DIFF
--- a/dev/serve.vue
+++ b/dev/serve.vue
@@ -4,7 +4,7 @@
       <button @click="active=true">You Can't Argue With Results</button>
     </Readme>
 
-    <Gaveta :active="active" @close="active = false">
+    <Gaveta :active="active" @close="active = false" size="is-medium">
       <template v-slot:title>
         A flexible drawer for your UI
       </template>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-gaveta",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "description": "The open-source and mobile-friendly drawer component bulit for Vue.js",
   "main": "dist/gaveta.ssr.js",
   "browser": "dist/gaveta.esm.js",
@@ -14,6 +14,7 @@
     "serve": "vue-cli-service serve dev/serve.js",
     "deploy": "npm run build-dev; npm run gh-pages",
     "gh-pages": "gh-pages -d public -b gh-pages",
+    "release": "npm run build; npm run deploy; npm publish",
     "build-dev": "rimraf ./public; vue-cli-service build dev/serve.js --dest public",
     "prebuild": "rimraf ./dist",
     "build": "cross-env NODE_ENV=production rollup --config build/rollup.config.js",

--- a/readme.md
+++ b/readme.md
@@ -85,4 +85,21 @@ export default {
 </Gaveta>
 ```
 
+#### Drawer Sizes
+
+Customize the maximum size of the drawer by adding the optional `size` property. 
+
+```vue
+<Gaveta size="is-large">
+```
+
+Below a screen size of `768px` the drawer will always be 92% of the total screen width. Above those screen dimenions the drawer sizes are: 
+
+value | result
+------|-------
+`is-small` | Drawer will be 320px wide 
+`is-medium` | (Default) Drawer will be 480px wide 
+`is-large` | Drawer will be 720px wide 
+
+
 Created by [@13protons](https://13protons.com) for [Farebox.io](https://farebox.io)

--- a/src/gaveta.vue
+++ b/src/gaveta.vue
@@ -1,7 +1,7 @@
 <template>
   <span>
     <transition name="drawer" appear>
-      <div v-if="active" class="drawer is-medium" >
+      <div v-if="active" class="drawer" :class="size">
         <button
           class="close-button"
           @click="close"
@@ -24,7 +24,6 @@
           </h3>
           <slot v-else name="title" class="gaveta-title" />
         </template>
-
         <slot name="default"></slot>
       </div>
     </transition>
@@ -38,6 +37,10 @@
 export default {
   props: {
     active: { type: Boolean, default: false },
+    size: { 
+      type: String, default: 'is-medium',
+      enum: ['is-small', 'is-medium', 'is-large']
+    }
   },
   directives: {
     focus: {
@@ -140,19 +143,38 @@ export default {
   border-bottom: 1px solid rgba(128, 128, 128, .5);
 }
 
-.drawer.is-medium {
-  width: 92vw;
+.drawer{
   box-shadow: -10px 0px 20px rgba(0, 0, 0, 0.25);
 }
 
+.drawer {
+  width: 92vw;
+}
+
 @media screen and (min-width: 768px) {
-  .drawer.is-medium {
-    width: 480px;
-  }
+  .drawer, .drawer.is-medium { width: 480px; }
+
+  .drawer.is-large { width: 720px; }
+
+  .drawer.is-small { width: 320px; }
+  
+
   .drawer-enter,
   .drawer-enter-from,
   .drawer-leave-to {
     transform: translate3d(500px, 0, 0);
+  }
+
+  .drawer.is-large.drawer-enter,
+  .drawer.is-large.drawer-enter-from,
+  .drawer.is-large.drawer-leave-to {
+    transform: translate3d(730px, 0, 0);
+  }
+
+  .drawer.is-small.drawer-enter,
+  .drawer.is-small.drawer-enter-from,
+  .drawer.is-small.drawer-leave-to {
+    transform: translate3d(330px, 0, 0);
   }
 }
 </style>


### PR DESCRIPTION
You can now pass in sizes to change the default width on larger screens, like so: 

* `is-small`: Drawer is 320px wide
* `is-medium`: (Default) Drawer is 480px wide
* `is-large`: Drawer is 720px wide. 

> Note: these sizes only apply to window sizes above 768px. Below that threshold and the drawer will always be 92% of the window's inner width. 